### PR TITLE
fix: 著作権ガイドラインがリンク切れしていたのを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mainブランチから各自ブランチを作成し、その中で作業を行�
 
 ## 参考リンク
 
-* [著作権ガイドライン](https://red.minecraftserver.jp/projects/public/wiki/Copyright_Guide#3%E7%AB%A0%E3%82%B5%E3%83%BC%E3%83%90%E3%83%86%E3%82%AF%E3%82%B9%E3%83%81%E3%83%A3)
+* [著作権ガイドライン](https://redmine.seichi.click/projects/public/wiki/Copyright_Guide#3%E7%AB%A0%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%83%86%E3%82%AF%E3%82%B9%E3%83%81%E3%83%A3)
 * [本パックを管理するGitHubリポジトリ](https://github.com/GiganticMinecraft/OriginalResourcePack)
 
 ## 謝辞


### PR DESCRIPTION
redmineアドレスが変更されており、リンク切れしていたため現在の [redmine.seichi.click ](https://redmine.seichi.click/projects/public/wiki/Copyright_Guide#3%E7%AB%A0%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%83%86%E3%82%AF%E3%82%B9%E3%83%81%E3%83%A3)に修正